### PR TITLE
F: Bind tools to Alt-Wheel and Alt-Shift-Wheel

### DIFF
--- a/src/lib/ToolBox.svelte
+++ b/src/lib/ToolBox.svelte
@@ -56,7 +56,7 @@
   let customSnappingDialogOpened: boolean = false
   let customSnappingDialogValue: number = 0
   $: customSnappingDialogValue = snapTo
-  let snappingSelect: HTMLSelectElement
+  export let snappingSelect: HTMLSelectElement
 </script>
 
 <div class="toolbox-container">

--- a/src/lib/control/ControlHandler.svelte
+++ b/src/lib/control/ControlHandler.svelte
@@ -5,6 +5,7 @@
     MODES,
     MODE_SHORTCUTS,
     MODE_SHORTCUTS_NUMERAL,
+    SnapTo,
   } from '$lib/editing/modes'
   import { KEYBOARD_SHORTCUTS } from '$lib/control/keyboard'
 
@@ -13,6 +14,7 @@
   // Stores
   import { inside } from '$lib/position'
   import { preferences } from '$lib/preferences'
+  import { resizingLastWidth } from '$lib/editing/resizing'
 
   type KeyboardEvents = {
     [K in KeyboardAction]: void
@@ -26,12 +28,25 @@
 
   export let zoom: number
   export let scrollTick: number
+  export let snappingSelect: HTMLSelectElement
+  export let snapTo: SnapTo
 
   function mousewheel(event: WheelEvent) {
     if (!$inside) return
     event.preventDefault()
     if (event.ctrlKey) {
       zoom -= (event.deltaY > 0 ? 0.1 : -0.1) * (event.shiftKey ? 10 : 1)
+    } else if (event.altKey && event.shiftKey) {
+      snappingSelect.selectedIndex = Math.min(
+        Math.max(snappingSelect.selectedIndex + (event.deltaY > 0 ? 1 : -1), 0),
+        snappingSelect.options.length - 2
+      )
+      snapTo = parseInt(snappingSelect.options[snappingSelect.selectedIndex].value)
+    } else if (event.altKey) {
+      $resizingLastWidth = Math.min(
+        Math.max($resizingLastWidth + (event.deltaY > 0 ? -1 : 1), 1),
+        12
+      )
     } else {
       scrollTick -=
         (event.deltaY *

--- a/src/routes/edit.svelte
+++ b/src/routes/edit.svelte
@@ -354,6 +354,7 @@
 
   let currentMode: Mode = 'select'
   let snapTo: SnapTo = SNAPTO_DEFAULT
+  let snappingSelect: HTMLSelectElement
 
   $: dbg('scrollTick', scrollTick)
 
@@ -1277,6 +1278,7 @@
       bind:currentMode
       bind:snapTo
       bind:openMainMenu
+      bind:snappingSelect
       on:about={() => {
         aboutDialogOpened = true
       }}
@@ -1687,6 +1689,8 @@
 <ControlHandler
   bind:zoom
   bind:scrollTick
+  bind:snapTo
+  bind:snappingSelect
   on:undo={onundo}
   on:redo={onredo}
   on:export={onexport}


### PR DESCRIPTION

https://user-images.githubusercontent.com/59691627/185745873-c2bfc49f-1665-4ff8-a17b-b24431264f30.mp4

Added a shortcut to `Alt-Wheel` and `Alt-Shift-Wheel`.
`Alt-Wheel` changes the note width without putting note, `Alt-Shift-Wheel` changes the snap.